### PR TITLE
Fix builds under gcc 13

### DIFF
--- a/db/compaction_iteration_stats.h
+++ b/db/compaction_iteration_stats.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 struct CompactionIterationStats {
   // Compaction statistics
 

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -8,6 +8,7 @@
 #pragma once
 #ifndef ROCKSDB_LITE
 
+#include <cstdint>
 #include <string>
 #include "rocksdb/status.h"
 

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Just one small thing that cropped up building under GCC 13

I can't tag our normal github group, or @cjuchem, presumably due to this being a StarryInternet repo (not a ProjectDecibel repo)

There is no CI in this repo, but here are the related builds showing that this change works in the F38 container:
https://github.com/StarryInternet/rust-rocksdb/pull/5
https://github.com/ProjectDecibel/major-tom/pull/265